### PR TITLE
Accessibility, mobile filtering, and visual polish for the front end

### DIFF
--- a/client.js
+++ b/client.js
@@ -59,6 +59,20 @@ class RfcFyiUi {
     this.title.onclick = function () {
       window.location = '/'
     }
+    const reloadBtn = document.getElementById('reloadBtn')
+    if (reloadBtn) reloadBtn.onclick = () => window.location.reload()
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') ui.resetToHome()
+    })
+  }
+
+  resetToHome () {
+    this.searchTarget.value = ''
+    this.searchWords = []
+    this.clearActiveTags()
+    this.showRfcs()
+    this.updateUrl()
+    this.searchTarget.focus()
   }
 
   installClickHandlers () {
@@ -66,6 +80,24 @@ class RfcFyiUi {
     sortByNum.onclick = (event) => { this.showRfcs(false); return false }
     const sortByRefs = document.getElementById('sortByRefs')
     sortByRefs.onclick = (event) => { this.showRfcs(true); return false }
+    const filterToggle = document.getElementById('filterToggle')
+    if (filterToggle) filterToggle.onclick = this.toggleFilters
+  }
+
+  toggleFilters (event) {
+    const container = document.getElementById('container')
+    const toggle = document.getElementById('filterToggle')
+    const open = container.classList.toggle('filters-open')
+    if (toggle) toggle.setAttribute('aria-expanded', open ? 'true' : 'false')
+    event.stopPropagation()
+    return false
+  }
+
+  updateFilterToggle () {
+    const toggle = document.getElementById('filterToggle')
+    if (!toggle) return
+    const n = this.activeTags.size
+    toggle.textContent = n > 0 ? `Filters (${n})` : 'Filters'
   }
 
   loadUi (...args) {
@@ -96,17 +128,29 @@ class RfcFyiUi {
 
   clearActiveTags () {
     this.activeTags.forEach((tagName, tagType) => {
-      const hilight = tagType !== 'collection'
-      if (hilight && this.tagTargets[tagType][tagName]) {
-        this.tagTargets[tagType][tagName].classList.remove('tag-active')
+      const target = this.tagTargets[tagType] ? this.tagTargets[tagType][tagName] : null
+      if (target) {
+        target.classList.remove('tag-active')
+        target.setAttribute('aria-pressed', 'false')
       }
     })
     this.activeTags.clear()
   }
 
   dataLoaded () {
+    if (data.loadError) {
+      ui.showDataError()
+      return
+    }
     ui.initTags()
     ui.showRfcs()
+  }
+
+  showDataError () {
+    const err = document.getElementById('dataError')
+    if (err) err.hidden = false
+    this.searchTarget.disabled = true
+    this.searchTarget.placeholder = 'Couldn’t load data'
   }
 
   showRfcs (sortByRef = true) {
@@ -154,7 +198,7 @@ class RfcFyiUi {
         collection: new Set(data.tags?.collection ? data.tags.collection.keys() : []),
         stream: new Set(data.tags?.stream ? data.tags.stream.keys() : [])
       }
-      this.showTags(relevantTags, false)
+      this.showTags(relevantTags, true)
     } else if (this.activeTags.has('collection')) { // show a collection
       this.showRelevantTags(relevantRfcs)
     } else if (this.searchWords.length === 0) { // just tags
@@ -169,6 +213,20 @@ class RfcFyiUi {
     this.clear(countTarget)
     countTarget.appendChild(count)
 
+    // empty state
+    const emptyTarget = document.getElementById('empty')
+    if (emptyTarget) {
+      if (userInput && rfcList.length === 0) {
+        emptyTarget.textContent = this.verbose
+          ? 'No RFCs match. Try a broader term, check the spelling, or pick a collection.'
+          : 'No RFCs match. Try a broader term, or tick “Show obsolete and historic RFCs” to include older ones.'
+        emptyTarget.hidden = false
+      } else {
+        emptyTarget.hidden = true
+      }
+    }
+
+    this.updateFilterToggle()
     this.setContainer(rfcList.length > 0 || userInput)
   }
 
@@ -181,7 +239,7 @@ class RfcFyiUi {
     const rfcRef = document.createElement('a')
     rfcRef.className = 'reference'
     rfcRef.href = `https://bib.ietf.org/public/rfc/bibxml/reference.RFC.${rfcNum}.xml`
-    rfcRef.appendChild(document.createTextNode(`RFC${rfcNum}`))
+    rfcRef.appendChild(document.createTextNode(`RFC\u00A0${rfcNum}`))
     rfcSpan.appendChild(rfcRef)
     const sep = document.createTextNode(': ')
     rfcSpan.appendChild(sep)
@@ -203,8 +261,8 @@ class RfcFyiUi {
     if (hideRefs !== true && refCount > 0) {
       const refSpan = document.createElement('span')
       refSpan.className = 'refcount'
-      const refCountLink = document.createElement('a')
-      refCountLink.href = '#'
+      const refCountLink = document.createElement('button')
+      refCountLink.type = 'button'
       refCountLink.className = 'refcountlink'
       refCountLink.onclick = this.refExpandHandler
       const refCountText = document.createTextNode(`${refCount.toLocaleString()} referencing RFC${this.pluralise(refCount)}`)
@@ -250,13 +308,16 @@ class RfcFyiUi {
 
   renderTag (tagType, tagName, target, clickHandlerFactory) {
     const tagData = data.tags[tagType][tagName]
+    const interactive = clickHandlerFactory !== undefined
     const tagContent = document.createTextNode(tagName)
-    const tagSpan = document.createElement('span')
+    const tagSpan = document.createElement(interactive ? 'button' : 'span')
+    if (interactive) tagSpan.type = 'button'
     tagSpan.appendChild(tagContent)
     tagSpan.classList.add('tag')
     tagSpan.style.backgroundColor = tagData.colour || this.tagColours[tagType] || util.genColour(tagName)
     tagSpan.style.color = util.revColour(tagSpan.style.backgroundColor)
-    if (clickHandlerFactory !== undefined) {
+    if (interactive) {
+      tagSpan.setAttribute('aria-pressed', 'false')
       tagSpan.onclick = clickHandlerFactory(tagType, tagName)
     } else {
       tagSpan.style.cursor = 'default'
@@ -280,11 +341,19 @@ class RfcFyiUi {
     const hilight = tagType !== 'collection'
     const currentActiveTag = ui.activeTags.get(tagType)
     if (currentActiveTag) {
-      if (hilight) this.tagTargets[tagType][currentActiveTag].classList.remove('tag-active')
+      const prev = this.tagTargets[tagType][currentActiveTag]
+      if (prev) {
+        if (hilight) prev.classList.remove('tag-active')
+        prev.setAttribute('aria-pressed', 'false')
+      }
       this.activeTags.delete(tagType)
     }
     if (!currentActiveTag || currentActiveTag !== tagName) {
-      if (hilight) this.tagTargets[tagType][tagName].classList.add('tag-active')
+      const next = this.tagTargets[tagType][tagName]
+      if (next) {
+        if (hilight) next.classList.add('tag-active')
+        next.setAttribute('aria-pressed', 'true')
+      }
       this.activeTags.set(tagType, tagName)
     }
   }
@@ -337,11 +406,7 @@ class RfcFyiUi {
   }
 
   clearSearchHandler (event) {
-    ui.searchTarget.value = ''
-    ui.searchWords = []
-    ui.activeTags.clear()
-    ui.showRfcs()
-    ui.updateUrl()
+    ui.resetToHome()
     event.stopPropagation()
     return false
   }
@@ -381,7 +446,14 @@ class RfcFyiUi {
 
   setContainer (hasResults) {
     const container = document.getElementById('container')
+    const filtersOpen = hasResults && container.classList.contains('filters-open')
     container.className = hasResults ? 'results' : 'noresults'
+    if (filtersOpen) {
+      container.classList.add('filters-open')
+    } else {
+      const toggle = document.getElementById('filterToggle')
+      if (toggle) toggle.setAttribute('aria-expanded', 'false')
+    }
   }
 
   rfcSort (a, b) {

--- a/data.js
+++ b/data.js
@@ -27,6 +27,7 @@ export default class RfcData {
     })
     .catch(error => {
       console.error('[Data] Failed to load data:', error)
+      this.loadError = error
       this.tags = this.tags || {}
       this.rfcs = this.rfcs || {}
       this.refs = this.refs || []

--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
   <meta name="twitter:image" content="https://rfc.fyi/rfcfyi.png" />
   <meta name="description" content="rfc.fyi lets you search the RFC Series - fast!">
   <link rel="manifest" href="manifest.json">
-  <meta name="theme-color" content="#ffffff">
+  <meta name="theme-color" content="#fcfcfc" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#222222" media="(prefers-color-scheme: dark)">
   <link rel="modulepreload" href="/util.js" as="script" />
   <link rel="modulepreload" href="/data.js" as="script" />
   <link rel="preload" href="/var/tags.json" as="fetch" />
@@ -30,28 +31,34 @@
 
     <h1 id="title">rfc<span class="dot">.</span><span class="fyi">fyi</span></h1>
 
-    <div id="form"><form>
-      <input type="text" id="search" value="" autocomplete="off" spellcheck="false" autocorrect="off" autocapitalize="off" enterkeyhint="go" placeholder="Loading..." disabled="true"><span id="clearSearch">x</span>
-      <p><label class="control" title="Specifiations that have been obsoleted or Historic."><input type="checkbox" id="obsolete"> Show obsolete and historic</label></p>
+    <div id="form"><form role="search" aria-label="Search RFCs">
+      <span class="search-field"><input type="text" id="search" value="" autocomplete="off" spellcheck="false" autocorrect="off" autocapitalize="off" enterkeyhint="go" aria-label="Search RFC titles and keywords" placeholder="Loading..." disabled="true"><button type="button" id="clearSearch" aria-label="Clear search">&times;</button></span>
+      <p><label class="control" title="Include RFCs that have been obsoleted by a newer RFC, or marked Historic."><input type="checkbox" id="obsolete"> Show obsolete and historic RFCs</label></p>
     </form></div>
 
-    <p id="sort" class="control">sort by:<br/><a href="#" id="sortByNumber">RFC number</a> | <a href="#" id="sortByRefs">referencing RFCs</a></p>
+    <p id="dataError" class="error" role="alert" hidden>Couldn’t load the RFC index. Check your connection and <button type="button" id="reloadBtn" class="linklike">reload</button>.</p>
+
+    <p id="sort" class="control">sort by:<br/><button type="button" class="sortlink" id="sortByNumber">RFC number</button> | <button type="button" class="sortlink" id="sortByRefs">referencing RFCs</button></p>
 
     <p class="start">Try “congestion”, “Cisco”, “IMAP search”, “UDP”, “firewall” or “privacy”.</p>
 
-    <p class="start"><em>Or, choose a collection to start with:</em></p>
+    <p class="start"><em>Or browse by:</em></p>
 
-    <h2 id="collection-header" class="tags">Collection</h2>
-    <div id="collection" class="tags"></div>
-    <h2 id="stream-header" class="tags">Stream</h2>
-    <div id="stream" class="tags"></div>
-    <h2 id="level-header" class="tags">Level</h2>
-    <div id="level" class="tags"></div>
-    <h2 id="wg-header" class="tags">Working Group</h2>
-    <div id="wg" class="tags"></div>
+    <button type="button" id="filterToggle" class="control" aria-expanded="false" aria-controls="facets">Filters</button>
+
+    <div id="facets">
+      <h2 id="collection-header" class="tags">Collection</h2>
+      <div id="collection" class="tags"></div>
+      <h2 id="stream-header" class="tags">Stream</h2>
+      <div id="stream" class="tags"></div>
+      <h2 id="level-header" class="tags">Level</h2>
+      <div id="level" class="tags"></div>
+      <h2 id="wg-header" class="tags">Working Group</h2>
+      <div id="wg" class="tags"></div>
+    </div>
 
   <div class="footer">
-    <a title="GitHub" href="https://github.com/mnot/rfc.fyi/">
+    <a title="GitHub" aria-label="rfc.fyi source on GitHub" href="https://github.com/mnot/rfc.fyi/">
           <svg height="24" class="octicon" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>
     </a>
   </div>
@@ -59,10 +66,11 @@
 
   </div>
   <div id="shadow"></div>
-  <div id="main">
-    <div id="count"></div>
+  <main id="main">
+    <div id="count" role="status" aria-live="polite" aria-atomic="true"></div>
     <ul id="rfc-list"></ul>
-  </div>
+    <p id="empty" class="empty-state" hidden></p>
+  </main>
 
 </div>
 </body>

--- a/style.css
+++ b/style.css
@@ -13,6 +13,11 @@
   --accent-dot: #c9bc38;
   --accent-close: #c99;
   --icon-fill: #aaa;
+  --focus-ring: #0b57d0;
+  --error-text: #b3261e;
+  --shadow-tag: 0 1px 2px rgba(0, 0, 0, 0.16);
+  --shadow-input: 0 1px 2px rgba(0, 0, 0, 0.07);
+  --scrollbar-thumb: #c9c9c9;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -27,7 +32,17 @@
     --accent-dot: #e6db74;
     --accent-close: #e06c75;
     --icon-fill: #777;
+    --focus-ring: #8ab4f8;
+    --error-text: #f2b8b5;
+    --shadow-tag: 0 1px 2px rgba(0, 0, 0, 0.45);
+    --shadow-input: 0 1px 2px rgba(0, 0, 0, 0.35);
+    --scrollbar-thumb: #555;
   }
+}
+
+:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 body {
@@ -36,7 +51,7 @@ body {
   font: 12pt/14pt "Helvetica Neue", Helvetica, Arial, sans-serif;
   margin: 0;
   padding: 1em 5%;
-  max-width: 1200px;
+  max-width: 1600px;
 }
 
 a:link,
@@ -64,8 +79,9 @@ a:active {
   /* Matches background to prevent visible border by default */
 }
 
-#form form {
+.search-field {
   position: relative;
+  display: block;
 }
 
 .noresults #selector {
@@ -102,7 +118,7 @@ a:active {
 }
 
 #count {
-  color: var(--text-faint);
+  color: var(--text-muted);
   font-size: 75%;
 }
 
@@ -117,8 +133,12 @@ ul {
 
 li {
   line-height: 1.55em;
-  text-indent: -4.7em;
-  margin-left: 4.7em;
+  text-indent: -5.75em;
+  margin-left: 5.75em;
+}
+
+#rfc-list > li {
+  margin-bottom: 0.25em;
 }
 
 li ul {
@@ -130,24 +150,55 @@ li ul {
   flex: 0;
 }
 
-.noresults .tags {
-  width: 60%;
-  margin: 0 auto 1em auto;
+/* Tag clouds: flex-wrap gives even horizontal + vertical spacing and centers
+   any lone wrapped tag so it doesn't read as a stray orphan. */
+div.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45em 0.5em;
+  margin: 0.35em 0 1.1em;
+}
+
+.noresults #facets {
+  max-width: 40em;
+  margin: 0 auto;
+}
+
+.noresults h2.tags {
   text-align: center;
+  margin: 1.5em 0 0.4em;
+}
+
+.noresults div.tags {
+  justify-content: center;
+  margin-bottom: 1.4em;
 }
 
 @media all and (max-width: 800px) {
 
-  .results .tags,
-  .results h2.tags,
-  .results #collection,
-  .results #stream,
-  .results #level,
-  .results #wg,
-  .results #collection-header,
-  .results #stream-header,
-  .results #level-header,
-  .results #wg-header,
+  .results #facets {
+    display: none;
+  }
+
+  .results #filterToggle {
+    display: block;
+    width: 100%;
+    margin: 0.5em 0 0;
+    padding: 12px;
+    text-align: center;
+    font: inherit;
+    color: var(--link-color);
+    background: none;
+    border: 1px solid var(--text-faint);
+    border-radius: 5px;
+    cursor: pointer;
+  }
+
+  .results.filters-open #facets {
+    display: block;
+    margin-top: 0.75em;
+  }
+
   .results .start em,
   .results .start em+p {
     display: none !important;
@@ -159,8 +210,21 @@ input#search {
   font-size: 18px;
   background-color: var(--bg-color);
   color: var(--text-main);
-  border: 1px solid var(--text-faint);
-  padding: 2px 25px 2px 10px;
+  border: 1px solid var(--text-muted);
+  border-radius: 8px;
+  box-shadow: var(--shadow-input);
+  padding: 8px 32px 8px 12px;
+}
+
+input#search::placeholder {
+  color: var(--text-muted);
+  opacity: 1;
+}
+
+input#search:focus {
+  outline: none;
+  border-color: var(--focus-ring);
+  box-shadow: var(--shadow-input), 0 0 0 1px var(--focus-ring);
 }
 
 .control {
@@ -171,28 +235,53 @@ input#search {
   display: none;
 }
 
+#filterToggle {
+  display: none;
+}
+
 .tag,
 .tag-active {
   display: inline;
-  padding: .25em .6em;
+  appearance: none;
+  -webkit-appearance: none;
+  font-family: inherit;
+  padding: .12em .6em;
   font-size: 75%;
   font-weight: 500;
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
-  border: 2px;
-  border-radius: 5px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  box-shadow: var(--shadow-tag);
   user-select: none;
   cursor: pointer;
   filter: none;
+  transition: filter 0.12s ease;
 }
 
 .tag-active {
   border: 1px solid var(--border-main);
 }
 
+@media (hover: hover) {
+  button.tag:hover {
+    filter: brightness(0.92);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tag {
+    transition: none;
+  }
+}
+
 li .tag {
   margin: 0 0 0 .75em;
+  padding-top: 0.08em;
+  padding-bottom: 0.08em;
+  line-height: 1.2;
+  vertical-align: middle;
 }
 
 h1 {
@@ -224,14 +313,21 @@ h2 {
 
 #clearSearch {
   position: absolute;
-  font-size: 16px;
-  top: 0px;
-  right: 4px;
+  appearance: none;
+  -webkit-appearance: none;
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-size: 18px;
+  line-height: 1;
+  top: 50%;
+  right: 6px;
+  transform: translateY(-50%);
   z-index: 100;
   cursor: pointer;
   user-select: none;
   color: var(--accent-close);
-  padding: 2px 6px;
+  padding: 4px 8px;
 }
 
 .noresults #clearSearch {
@@ -240,6 +336,7 @@ h2 {
 
 .footer {
   width: 100%;
+  margin-top: 2.5em;
   padding: 3px;
   text-align: center;
 }
@@ -250,6 +347,7 @@ h2 {
 
 .reference {
   color: var(--text-ref);
+  font-weight: 600;
 }
 
 .status-obsoleted .reference,
@@ -258,9 +356,36 @@ h2 {
 }
 
 .refcountlink {
+  appearance: none;
+  -webkit-appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
   font-size: 75%;
   margin-left: 1em;
   white-space: nowrap;
+  color: var(--link-color);
+  cursor: pointer;
+}
+
+.refcountlink:hover {
+  text-decoration: underline;
+}
+
+.sortlink {
+  appearance: none;
+  -webkit-appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--link-color);
+  cursor: pointer;
+}
+
+.sortlink:hover {
+  text-decoration: underline;
 }
 
 .sort-active {
@@ -268,6 +393,47 @@ h2 {
   color: var(--text-main);
   text-decoration: none;
   cursor: default;
+}
+
+.linklike {
+  appearance: none;
+  -webkit-appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--link-color);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.empty-state {
+  margin: 2em 0;
+  color: var(--text-muted);
+  max-width: 55ch;
+}
+
+.error {
+  color: var(--error-text);
+  font-weight: 500;
+}
+
+/* Touch devices: enlarge tap targets without affecting mouse density */
+@media (pointer: coarse) {
+  button.tag {
+    display: inline-block;
+    padding: .3em .7em;
+    margin-bottom: .35em;
+  }
+
+  #clearSearch {
+    padding: 10px 12px;
+  }
+
+  .sortlink {
+    display: inline-block;
+    padding: 8px 6px;
+  }
 }
 
 @media all and (max-width: 800px) {
@@ -293,21 +459,8 @@ h2 {
     width: 100%;
   }
 
-  .results #selector h2,
-  .results #selector div.tags,
-  .results #selector .tag,
-  .results .tags,
-  .results h2.tags,
   .results .start em,
   .results .start em+p,
-  .results #collection,
-  .results #stream,
-  .results #level,
-  .results #wg,
-  .results #collection-header,
-  .results #stream-header,
-  .results #level-header,
-  .results #wg-header,
   .results p.start {
     display: none !important;
   }
@@ -340,10 +493,12 @@ h2 {
     overflow-y: auto;
     height: 100%;
     border-right: none;
+    scrollbar-width: thin;
+    scrollbar-color: var(--scrollbar-thumb) transparent;
   }
 
   #selector::-webkit-scrollbar {
-    width: 1px;
+    width: 10px;
   }
 
   #selector::-webkit-scrollbar-track {
@@ -351,9 +506,12 @@ h2 {
   }
 
   #selector::-webkit-scrollbar-thumb {
-    background-color: #d1d1d1;
-    /* Subtler grey for thumb */
+    background-color: var(--scrollbar-thumb);
     border-radius: 10px;
+    /* Transparent border + padding-box clip insets the thumb so it sits with
+       breathing room from the sidebar edge rather than flush against it. */
+    border: 3px solid transparent;
+    background-clip: padding-box;
   }
 
   #shadow {

--- a/util.js
+++ b/util.js
@@ -17,13 +17,22 @@ export function genColour (str) {
 }
 
 export function revColour (inColour) {
-  const rgb = inColour.match(/\d+/g)
-  const luma = 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2] // ITU-R BT.709
-  if (luma < 128) {
-    return '#fff'
-  } else {
-    return '#000'
+  const rgb = inColour.match(/\d+/g).map(Number)
+  // Pick whichever of white/black gives the higher WCAG contrast against the
+  // background. The max-contrast choice is always >= 4.58:1 for any colour, so
+  // tag labels stay legible whatever the (curated or hash-generated) background.
+  const lum = relativeLuminance(rgb)
+  const contrastWhite = 1.05 / (lum + 0.05)
+  const contrastBlack = (lum + 0.05) / 0.05
+  return contrastWhite >= contrastBlack ? '#fff' : '#000'
+}
+
+function relativeLuminance ([r, g, b]) {
+  const channel = c => {
+    c /= 255
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
   }
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
 }
 
 Set.prototype.intersection = function (setB) { // eslint-disable-line


### PR DESCRIPTION
## What & why

A pass over the rfc.fyi front end focused on **accessibility**, **mobile parity**, and **visual polish**, while keeping the site's fast, minimal character. The search core was already good; the gaps were mostly at the edges (keyboard/screen-reader operability, mobile, contrast, empty/error states) plus some visual refinement.

### Accessibility
- Facet tags, the clear "×", the sort controls, and the reference-count expander are now real `<button>`s with `aria-pressed`/labels and a visible `:focus-visible` ring — **the whole faceted-filtering flow now works by keyboard and screen reader** (it was mouse-only `<span onclick>`/`<a href="#">`).
- Added landmarks (`<main>`, `role="search"`), an accessible name on the search field, and a polite live region on the result count so counts are announced.
- Contrast raised to WCAG AA for the result count, search placeholder, and the search-box border. Tag **text** colour is now chosen by *maximum* WCAG contrast rather than a naive luma threshold, which guarantees ≥4.58:1 on every tag — curated or hash-generated — with no change to the tag backgrounds.

### Mobile
- Facets were `display:none` in the results view on phones; they're now reachable via a **"Filters" disclosure** (a real `<button aria-expanded>`), so the guided browse path survives on mobile. Touch targets enlarged on coarse pointers.

### Robustness
- A helpful **empty-search state**, and a **data-load failure state** with a reload action instead of silently rendering an empty, broken-looking page.

### Copy
- Fixed a typo, completed the "Show obsolete and historic RFCs" label, and surfaced the **Collection / Stream headers on the home screen** so the tag clusters aren't anonymous to newcomers.

### Visual polish
- Softer rounded search box and tags with subtle depth; a more **scannable result list** (bold RFC numbers as scan anchors, tighter rhythm); even tag-cloud spacing via flex; a **wider layout on large screens**; **Escape returns to the front page**; a space in `RFC NNNN` (non-breaking) with the hanging indent widened to align 5-digit numbers; and a **tokenized, theme-aware sidebar scrollbar**.

## Notes for reviewers
- CSS-first throughout — no framework, no new dependencies. JS changes are confined to `client.js`/`data.js`/`util.js` and pass `standard` clean.
- Dark mode and both light/dark contrast were verified at each step.
- **PWA cache:** after deploy, run `make pwa-update` so the service worker serves the new HTML/CSS/JS to returning users.
- Intentionally **not** included in this PR: `PRODUCT.md` (an auto-generated design-strategy doc), `.impeccable/` (review snapshots), and `.claude/launch.json` (local preview config). Happy to add `PRODUCT.md` if you'd like it in-repo.

---

🤖 Generated by Claude (Opus 4.8) via the "impeccable" design workflow, under **close human direction**: the maintainer drove each step, reviewed rendered screenshots at every iteration in the browser, and gave specific corrective feedback (element centering, spacing, softening, tag heights, RFC-number formatting, scrollbar behaviour) that shaped the result. Every change was verified live (light/dark, desktop/mobile) before landing.
