### PR TITLE
Fix RFC list wrapping with a table-style two-column grid

### DIFF
--- a/client.js
+++ b/client.js
@@ -241,21 +241,21 @@ class RfcFyiUi {
     rfcRef.href = `https://bib.ietf.org/public/rfc/bibxml/reference.RFC.${rfcNum}.xml`
     rfcRef.appendChild(document.createTextNode(`RFC\u00A0${rfcNum}`))
     rfcSpan.appendChild(rfcRef)
-    const sep = document.createTextNode(': ')
-    rfcSpan.appendChild(sep)
+    const rfcBody = document.createElement('span')
+    rfcBody.className = 'rfc-body'
     const rfcLink = document.createElement('a')
     rfcLink.href = `https://www.rfc-editor.org/info/rfc${rfcNum}/`
-    rfcSpan.appendChild(rfcLink)
+    rfcBody.appendChild(rfcLink)
     const rfcTitle = document.createTextNode(rfcData.title)
     rfcLink.appendChild(rfcTitle)
     if (rfcData.stream !== 'ietf') {
-      this.renderTag('stream', rfcData.stream, rfcSpan)
+      this.renderTag('stream', rfcData.stream, rfcBody)
     }
     if (rfcData.level !== 'std') {
-      this.renderTag('level', rfcData.level, rfcSpan)
+      this.renderTag('level', rfcData.level, rfcBody)
     }
     if (rfcData.wg) {
-      this.renderTag('wg', rfcData.wg, rfcSpan)
+      this.renderTag('wg', rfcData.wg, rfcBody)
     }
     const refCount = data.obsoleteRefs.get(rfcName)
     if (hideRefs !== true && refCount > 0) {
@@ -268,14 +268,15 @@ class RfcFyiUi {
       const refCountText = document.createTextNode(`${refCount.toLocaleString()} referencing RFC${this.pluralise(refCount)}`)
       refCountLink.appendChild(refCountText)
       refSpan.appendChild(refCountLink)
-      rfcSpan.appendChild(refSpan)
+      rfcBody.appendChild(refSpan)
     }
+    rfcSpan.appendChild(rfcBody)
     target.appendChild(rfcSpan)
   }
 
   refExpandHandler (event) {
     const refList = document.createElement('ul')
-    const rfcElement = event.target.parentElement.parentElement
+    const rfcElement = event.target.closest('li')
     const rfcName = data.rfcNumtoName(rfcElement.num)
     const rfcRefs = data.getObsoleteRefs(rfcName)
     rfcRefs.forEach(ref => {

--- a/style.css
+++ b/style.css
@@ -132,17 +132,28 @@ ul {
 }
 
 li {
+  display: grid;
+  grid-template-columns: 5.5em 1fr;
+  column-gap: 0.6em;
   line-height: 1.55em;
-  text-indent: -5.75em;
-  margin-left: 5.75em;
 }
 
 #rfc-list > li {
   margin-bottom: 0.25em;
 }
 
+li .reference {
+  text-align: right;
+}
+
 li ul {
-  margin-left: -0.5em;
+  margin: 0.25em 0 0;
+  padding-left: 0;
+}
+
+li ul li {
+  grid-template-columns: 4.5em 1fr;
+  margin-bottom: 0.25em;
 }
 
 .noresults #main {


### PR DESCRIPTION
## Summary

- The RFC list wraps awkwardly on narrow viewports: it used a negative-`text-indent`/`margin-left` hack to fake a hanging indent, so wrapped title lines land under the RFC number instead of under the title.
- Replaced that hack with a real two-column CSS Grid layout on each `<li>`: a fixed-width, right-aligned RFC number column and a flexible content column for title, tags, and reference count. It reads like a table without needing an actual `<table>`, and the nested "referencing RFCs" sublist inherits the same alignment.
- `client.js` now wraps the title/tags/refcount in a `.rfc-body` span so the grid has a clean second column. `refExpandHandler` switched from a fixed `parentElement.parentElement` chain to `closest('li')` to tolerate the added wrapper level.

## Test plan

- [x] Verified in a live browser preview at mobile (375px), a narrow dark-mode viewport (400px), and desktop (1280px) widths — wrapped titles align correctly under the title column.
- [x] Expanded a "referencing RFCs" sublist to confirm the nested list keeps the same column alignment.
- [x] `standard client.js` lint passes.

---
This PR was written entirely by Claude Code (Sonnet 5) based on a plain-language request from the repo owner ("adjust so it wraps like a table, with right-aligned RFC numbers"). The owner reviewed the rendered result in-session (mobile/desktop/dark-mode screenshots) before requesting this PR; no human hand-edited the diff.
